### PR TITLE
explicit declaration of top: 0 fixes firefox bug

### DIFF
--- a/app/styles/components/_nav.scss
+++ b/app/styles/components/_nav.scss
@@ -18,6 +18,7 @@
       > * {
         width: 100%;
         position: absolute;
+        top: 0;
         left: 0;
       }
     }


### PR DESCRIPTION
Not _exactly_ sure why, but default value for `top` is `auto`. While `auto` should probably be `0` in this case, explicitly declaring it as `top: 0;` fixes the bug.
